### PR TITLE
Honor clone depth property from pipeline on checkout

### DIFF
--- a/engine/compiler/compiler.go
+++ b/engine/compiler/compiler.go
@@ -209,6 +209,7 @@ func (c *Compiler) Compile(ctx context.Context) *engine.Spec {
 					Commit: c.Build.After,
 					Ref:    c.Build.Ref,
 					Remote: c.Repo.HTTPURL,
+					Depth:  c.Pipeline.Clone.Depth,
 				},
 			),
 		)


### PR DESCRIPTION
When using the SSH runner from DockerHub `drone/drone-runner-ssh:latest` with a pipeline like:

```yaml
kind: pipeline
type: ssh
name: ci

server:
  host: XXX
  user: XXX
  ssh_key:
    from_secret: XXX

clone:
  depth: 1

steps:
- name: hello
  commands:
  - echo Hello
```

...the output shows that the `depth: 1` property is not respected although the [docs say so](https://docker-runner.docs.drone.io/configuration/cloning):

```
+ git init
Initialized empty Git repository in /tmp/drone-DNfuPrrazu5C3MMX/drone/src/.git/
+ git remote add origin XXX
+ git fetch  origin +refs/heads/add-ci:
From XXX
 * branch            add-ci     -> FETCH_HEAD
 * [new branch]      add-ci     -> origin/add-ci
+ git checkout XXX -b add-ci
Switched to a new branch 'add-ci'
```

Looking at the source code the relevant code seems to be at https://github.com/drone-runners/drone-runner-ssh/blob/8d2ec31973b4701737904e5fc3ed334bca00aaa8/engine/compiler/compiler.go#L207-L212 not passing the information.

This PR addresses that problem and I already verified with a locally built Docker image that it works: `+ git fetch --depth=1 origin +refs/heads/add-ci:`