### PR TITLE
Update to Alpine 3.12 dropping unsupported 3.6

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,7 +1,7 @@
-FROM alpine:3.6 as alpine
+FROM alpine:3.12 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.12
 EXPOSE 3000
 
 ENV GODEBUG netdns=go

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -1,7 +1,7 @@
-FROM alpine:3.6 as alpine
+FROM alpine:3.12 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.12
 EXPOSE 3000
 
 ENV GODEBUG netdns=go

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,7 +1,7 @@
-FROM alpine:3.6 as alpine
+FROM alpine:3.12 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.6
+FROM alpine:3.12
 EXPOSE 3000
 
 ENV GODEBUG netdns=go


### PR DESCRIPTION
Using a supported Alpine release ensures security fixes, updates CA certificates and Alpine 3.6 is unsupported since May 2019 as per source: https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases

I built a Docker image with Alpine 3.12 locally and it works fine. This is to be expected since the drone-runner-ssh Docker image does not depend on anything special from Alpine, just shipping a go binary so it should be fine.